### PR TITLE
Compile kotlin with unresolved resource references

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace = "vtsen.hashnode.dev.newemptycomposeapp"
+    namespace = "com.qali.hesabi"
     compileSdk = 34
 
     defaultConfig {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.qali.hesabi">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Align Android namespace and manifest package to resolve R class generation error.

The `R` class was not being generated correctly because the `namespace` in `app/build.gradle.kts` did not match the application's package, and the `package` attribute was missing from `AndroidManifest.xml`. This fix ensures consistency, allowing the build system to correctly generate resource references.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6c382941-e562-4ca5-be2f-d088d82f827f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6c382941-e562-4ca5-be2f-d088d82f827f)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)